### PR TITLE
fix: toBool converting string type to boolean without evaluation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,7 +53,7 @@ var utils = {
   toBool: (str) =>
     str.replace(
       /((?<=([=:(,|&[]|return|=>))|^)[\s\n]*!{1,2}(\[\]|0|1)[\s\n]*((?=[;,)}|&\]])|$)/g,
-      (m) => ' ' + Boolean(m),
+      (m) => ' ' + Boolean(eval(m)),
     ),
 
   propArr: (str) => str.replace(/\[\((['"])((?![^_a-zA-Z$])[\w$]*)['"]\)\]/gi, '[$1$2$1]'),


### PR DESCRIPTION
Fixes #77 

Currently toBool utility function tries to turn string into booleans without evaluation, resulting in all non-empty strings to evaluate to true. 